### PR TITLE
chore: bump to version 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Discussion][github-discussions-badge]][github-discussions-link]
 [![Gitter][gitter-badge]][gitter-link]
 [![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
-<!--[![Conda-Forge][conda-badge]][conda-link]-->
+[![Conda-Forge][conda-badge]][conda-link]
 
 uproot-browser is a [plotext](https://github.com/piccolomo/plotext) based command line library in which the command line interface is provided by [Click](https://github.com/pallets/click). It is powered by [Hist](https://github.com/scikit-hep/hist) and it's TUI is put together by [Textual](https://github.com/Textualize/textual). Its aim is to enable a user to browse and look inside a ROOT file, completely via the terminal. It takes its inspiration from the [ROOT object browser](https://root.cern/doc/master/classTRootBrowser.html).
 
@@ -168,7 +168,7 @@ uproot-browser tree ../scikit-hep-testdata/src/skhep_testdata/data/uproot-Event.
 
 ## Development
 
-<!-- [![pre-commit.ci status][pre-commit-badge]][pre-commit-link] -->
+[![pre-commit.ci status][pre-commit-badge]][pre-commit-link]
 [![Code style: black][black-badge]][black-link]
 
 See [CONTRIBUTING.md](https://github.com/henryiii/uproot-browser/blob/main/.github/CONTRIBUTING.md) for details on how to set up a development environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "uproot_browser"
+version = "0.4.0"
 authors = [
   { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ classifiers = [
   "Typing :: Typed",
 ]
 
-
-dynamic = ["version"]
 dependencies = [
   "awkward >=1",
   "click >=8",
@@ -66,8 +64,8 @@ dev = [
 ]
 
 [project.urls]
-homepage = "https://github.com/henryiii/uproot-browser"
-repository = "https://github.com/henryiii/uproot-browser"
+homepage = "https://github.com/scikit-hep/uproot-browser"
+repository = "https://github.com/scikit-hep/uproot-browser"
 
 [project.scripts]
 uproot-browser = "uproot_browser.__main__:main"

--- a/src/uproot_browser/__init__.py
+++ b/src/uproot_browser/__init__.py
@@ -4,6 +4,4 @@ interface is provided currently.
 """
 from __future__ import annotations
 
-__version__ = "0.3.1"
-
-__all__ = ("__version__",)
+__all__ = ()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-import uproot_browser as m
-
-
-def test_version():
-    assert m.__version__


### PR DESCRIPTION
Dropping `__version__`; while I'm in the "it's nice to have" camp, maintaining a version in pyproject.toml is easier (I'll assume it's automatic otherwise), and it's not worth the bother to add `importlib_metadata` to make this work the other direction. This is not a library, so no one should be importing it anyway.

Added pre-commit.ci, and a placeholder badge for https://github.com/conda-forge/staged-recipes/pull/18382.
