### PR TITLE
chore: update minimum required uproot version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "lz4",
   "numpy >=1.13.3",
   "rich >=12.0.0",
-  "uproot >=4.0",
+  "uproot >=4.2.1",
   "plotext >=4.1.0",
   "hist >=2.4",
   "textual >=0.1.17",


### PR DESCRIPTION
- Update minimum required to uproot version to `4.2.1` due to the change in `fBits` size definition
- Refer to [4d0ef10](https://github.com/amangoel185/uproot-browser/commit/4d0ef10fef4ea9e6dd4f46c3179452a9c7d06774) and scikit-hep/uproot4/pull/570