### PR TITLE
fix: bump black to 22.3.0 due to click 8.1 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,12 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.941
+  rev: v0.942
   hooks:
   - id: mypy
     files: src
     args: [--show-error-codes]
-    additional_dependencies: [rich, click, hist, numpy, textual==0.1.17]
+    additional_dependencies: [rich>=12, click<8.1, hist, numpy, textual==0.1.17]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos