### PR TITLE
chore: cleanup dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # Official actions have moving tags like v1
-      # that are used, so they don't need updates here
-      - dependency-name: "actions/*"


### PR DESCRIPTION
Remove obsolete configuration from `dependabot.yml` similar to scikit-hep/hist#420
