### PR TITLE
fix: Link directory paths to directory names

### DIFF
--- a/src/uproot_browser/tree.py
+++ b/src/uproot_browser/tree.py
@@ -88,10 +88,20 @@ def _process_item_tfile(
     Given an TFile, return a rich.tree.Tree output.
     """
     path = Path(uproot_object.file_path)
+
+    if uproot_object.path:
+        # path is to a TDirectory on tree
+        path_name = escape(uproot_object.path[0])
+        link_text = f"file://{path}:/{path_name}"
+    else:
+        # path is the top of the tree: the file
+        path_name = escape(path.name)
+        link_text = f"file://{path}"
+
+    label = Text.from_markup(f":file_folder: [link {link_text}]{path_name}")
+
     result = {
-        "label": Text.from_markup(
-            f":file_folder: [link file://{path}]{escape(path.name)}"
-        ),
+        "label": label,
         "guide_style": "bold bright_blue",
     }
     return result


### PR DESCRIPTION
Resolves #47

* Determine if the read only directory path is the top of the tree (and so an empty tuple) or if it is a path inside of the file. From this link the directory (file) path to the directory (file) name.

## Before

```
uproot-browser tree /tmp/FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root
```

📁 FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root
┣━━ 📁 FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root
┃   ┗━━ 🌴 Events (40600)
┃       ┣━━ 🍃 electron_ch std::vector<float>
┃       ┣━━ 🍃 electron_dxy std::vector<float>
┃       ┣━━ 🍃 electron_dxyError std::vector<float>
┃       ┣━━ 🍃 electron_dz std::vector<float>
┃       ┣━━ 🍃 electron_dzError std::vector<float>
┃       ┣━━ 🍃 electron_e std::vector<float>
┃       ┣━━ 🍃 electron_eta std::vector<float>
┃       ┣━━ 🍃 electron_isLoose std::vector<bool>
┃       ┣━━ 🍃 electron_isMedium std::vector<bool>
┃       ┣━━ 🍃 electron_isTight std::vector<bool>
┃       ┣━━ 🍃 electron_iso std::vector<float>
┃       ┣━━ 🍃 electron_phi std::vector<float>
┃       ┣━━ 🍃 electron_pt std::vector<float>
┃       ┣━━ 🍃 electron_px std::vector<float>
┃       ┣━━ 🍃 electron_py std::vector<float>
┃       ┣━━ 🍃 electron_pz std::vector<float>
┃       ┗━━ 🍁 numberelectron int32_t
...

with links of:

* 📁 FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root: `file:///tmp/FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root`

## After

```
uproot-browser tree /tmp/FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root
```

📁 FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root
┣━━ 📁 myelectrons
┃   ┗━━ 🌴 Events (40600)
┃       ┣━━ 🍃 electron_ch std::vector<float>
┃       ┣━━ 🍃 electron_dxy std::vector<float>
┃       ┣━━ 🍃 electron_dxyError std::vector<float>
┃       ┣━━ 🍃 electron_dz std::vector<float>
┃       ┣━━ 🍃 electron_dzError std::vector<float>
┃       ┣━━ 🍃 electron_e std::vector<float>
┃       ┣━━ 🍃 electron_eta std::vector<float>
┃       ┣━━ 🍃 electron_isLoose std::vector<bool>
┃       ┣━━ 🍃 electron_isMedium std::vector<bool>
┃       ┣━━ 🍃 electron_isTight std::vector<bool>
┃       ┣━━ 🍃 electron_iso std::vector<float>
┃       ┣━━ 🍃 electron_phi std::vector<float>
┃       ┣━━ 🍃 electron_pt std::vector<float>
┃       ┣━━ 🍃 electron_px std::vector<float>
┃       ┣━━ 🍃 electron_py std::vector<float>
┃       ┣━━ 🍃 electron_pz std::vector<float>
┃       ┗━━ 🍁 numberelectron int32_t
...

with links of

* 📁 FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root: `file:///tmp/FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root`
* 📁 myelectrons: `file:///tmp/FCBEF10A-19D4-E511-83BF-E41D2D08DCA0.root:/myelectrons`