### PR TITLE
fix: Note branch empty on panel instead of traceback

### DIFF
--- a/src/uproot_browser/exceptions.py
+++ b/src/uproot_browser/exceptions.py
@@ -1,0 +1,8 @@
+"""Custom exceptions for uproot-browser"""
+
+
+from __future__ import annotations
+
+
+class EmptyTreeError(ValueError):
+    pass

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -14,6 +14,9 @@ import numpy as np
 import plotext as plt
 import uproot
 
+class EmptyTreeError(ValueError):
+    pass
+
 
 def clf() -> None:
     """
@@ -56,7 +59,7 @@ def plot_branch(tree: uproot.TBranch) -> None:
     values = ak.flatten(array) if array.ndim > 1 else array
     finite = values[np.isfinite(values)]
     if len(finite) < 1:
-        raise ValueError(f"Branch {tree.name} is empty.")
+        raise EmptyTreeError(f"Branch {tree.name} is empty.")
     histogram: hist.Hist = hist.numpy.histogram(finite, bins=100, histogram=hist.Hist)
     plt.bar(histogram.axes[0].centers, histogram.values().astype(float))
     plt.ylim(lower=0)

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -55,6 +55,8 @@ def plot_branch(tree: uproot.TBranch) -> None:
     array = tree.array()
     values = ak.flatten(array) if array.ndim > 1 else array
     finite = values[np.isfinite(values)]
+    if len(finite) < 1:
+        raise ValueError(f"Branch {tree.name} is empty.")
     histogram: hist.Hist = hist.numpy.histogram(finite, bins=100, histogram=hist.Hist)
     plt.bar(histogram.axes[0].centers, histogram.values().astype(float))
     plt.ylim(lower=0)

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -14,9 +14,7 @@ import numpy as np
 import plotext as plt
 import uproot
 
-
-class EmptyTreeError(ValueError):
-    pass
+from uproot_browser.exceptions import EmptyTreeError
 
 
 def clf() -> None:

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -14,6 +14,7 @@ import numpy as np
 import plotext as plt
 import uproot
 
+
 class EmptyTreeError(ValueError):
     pass
 

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -57,7 +57,7 @@ class Plot:
         except uproot_browser.plot.EmptyTreeError:
             yield rich.panel.Panel(
                 rich.align.Align.center(
-                    rich.pretty.Pretty(f"{self.item.name} is EMPTY", no_wrap=True),
+                    f"[green]{self.item.name} is EMPTY",
                     vertical="middle",
                 ),
                 border_style="red",

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -14,6 +14,7 @@ import uproot
 
 import uproot_browser.dirs
 import uproot_browser.plot
+from uproot_browser.exceptions import EmptyTreeError
 
 EMPTY = object()
 
@@ -54,7 +55,7 @@ class Plot:
         try:
             canvas = make_plot(self.item, width, height)
             yield rich.text.Text.from_ansi(canvas)
-        except uproot_browser.plot.EmptyTreeError:
+        except EmptyTreeError:
             yield rich.panel.Panel(
                 rich.align.Align.center(
                     f"[green]{self.item.name} is EMPTY",

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -54,14 +54,26 @@ class Plot:
         try:
             canvas = make_plot(self.item, width, height)
             yield rich.text.Text.from_ansi(canvas)
-        except Exception:
-            tb = rich.traceback.Traceback(
-                extra_lines=1,
-                max_frames=self.max_frames,  # Can't be less than 4 frames
-                width=width,
-            )
-            tb.max_frames = self.max_frames
-            yield tb
+        except Exception as err:
+            if isinstance(err, ValueError):
+                yield rich.panel.Panel(
+                    rich.align.Align.center(
+                        rich.pretty.Pretty(f"{self.item.name} is EMPTY", no_wrap=True),
+                        vertical="middle",
+                    ),
+                    border_style="red",
+                    box=rich.box.ROUNDED,
+                    width=width,
+                    height=height,
+                )
+            else:
+                tb = rich.traceback.Traceback(
+                    extra_lines=1,
+                    max_frames=self.max_frames,  # Can't be less than 4 frames
+                    width=width,
+                )
+                tb.max_frames = self.max_frames
+                yield tb
 
 
 class PlotWidget(textual.widget.Widget):

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -65,7 +65,7 @@ class Plot:
                 width=width,
                 height=height,
             )
-        except Exception as err:
+        except Exception:
             tb = rich.traceback.Traceback(
                 extra_lines=1,
                 max_frames=self.max_frames,  # Can't be less than 4 frames

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -54,26 +54,25 @@ class Plot:
         try:
             canvas = make_plot(self.item, width, height)
             yield rich.text.Text.from_ansi(canvas)
+        except ValueError as err:
+            yield rich.panel.Panel(
+                rich.align.Align.center(
+                    rich.pretty.Pretty(f"{self.item.name} is EMPTY", no_wrap=True),
+                    vertical="middle",
+                ),
+                border_style="red",
+                box=rich.box.ROUNDED,
+                width=width,
+                height=height,
+            )
         except Exception as err:
-            if isinstance(err, ValueError):
-                yield rich.panel.Panel(
-                    rich.align.Align.center(
-                        rich.pretty.Pretty(f"{self.item.name} is EMPTY", no_wrap=True),
-                        vertical="middle",
-                    ),
-                    border_style="red",
-                    box=rich.box.ROUNDED,
-                    width=width,
-                    height=height,
-                )
-            else:
-                tb = rich.traceback.Traceback(
-                    extra_lines=1,
-                    max_frames=self.max_frames,  # Can't be less than 4 frames
-                    width=width,
-                )
-                tb.max_frames = self.max_frames
-                yield tb
+            tb = rich.traceback.Traceback(
+                extra_lines=1,
+                max_frames=self.max_frames,  # Can't be less than 4 frames
+                width=width,
+            )
+            tb.max_frames = self.max_frames
+            yield tb
 
 
 class PlotWidget(textual.widget.Widget):

--- a/src/uproot_browser/plot_view.py
+++ b/src/uproot_browser/plot_view.py
@@ -54,7 +54,7 @@ class Plot:
         try:
             canvas = make_plot(self.item, width, height)
             yield rich.text.Text.from_ansi(canvas)
-        except ValueError as err:
+        except uproot_browser.plot.EmptyTreeError:
             yield rich.panel.Panel(
                 rich.align.Align.center(
                     rich.pretty.Pretty(f"{self.item.name} is EMPTY", no_wrap=True),


### PR DESCRIPTION
Resolves #53.

In the event that a branch is empty, instead of catching the `Exception` and displaying the frames in the panel, raise a `ValueError` and catch that to display in the panel that the branch is 'EMPTY'.

## Before

```
uproot-browser browse /tmp/data_A.2lep.root
```

When opening a branch that is empty get a traceback from the caught exception.

![before](https://user-images.githubusercontent.com/5142394/196619412-699cf8df-a1a4-4004-a28b-dc310f903e7a.png)

## After

```
uproot-browser browse /tmp/data_A.2lep.root
```

When opening a branch that is empty get text of "{branch name} is EMPTY" (e.g. "largeRjet_D2 is EMPTY").

![after](https://user-images.githubusercontent.com/5142394/196619515-4cfdf731-7fb0-488e-ae42-ed76004b04fd.png)
