### PR TITLE
itermplot version correction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 ]
 iterm = [
   "matplotlib",
-  "itermplot",
+  "itermplot==0.5",
   "mplhep",
 ]
 dev = [


### PR DESCRIPTION

Just Added "itermplot==0.5" to the pyproject.toml, correct me if that wasn't the right place to change this.