### PR TITLE
Change x-axis to 5 regularly-spaced ticks

### DIFF
--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -64,6 +64,7 @@ def plot_branch(tree: uproot.TBranch) -> None:
     histogram: hist.Hist = hist.numpy.histogram(finite, bins=100, histogram=hist.Hist)
     plt.bar(histogram.axes[0].centers, histogram.values().astype(float))
     plt.ylim(lower=0)
+    plt.xticks(np.linspace(histogram.axes[0][0][0], histogram.axes[0][-1][-1], 5))
     plt.xlabel(histogram.axes[0].name)
     plt.title(make_hist_title(tree, histogram))
 
@@ -76,5 +77,6 @@ def plot_hist(tree: uproot.behaviors.TH1.Histogram) -> None:
     histogram = hist.Hist(tree.to_hist())
     plt.bar(histogram.axes[0].centers, histogram.values().astype(float))
     plt.ylim(lower=0)
+    plt.xticks(np.linspace(histogram.axes[0][0][0], histogram.axes[0][-1][-1], 5))
     plt.xlabel(histogram.axes[0].name)
     plt.title(make_hist_title(tree, histogram))


### PR DESCRIPTION
Plotext has a sane default of displaying five regularly-spaced ticks on the x-axis when using `plt.hist`. However, since uproot-browser uses `hist.Hist` to do the histogramming (and for good reason), Plotext changes to insane plot ticks for some reason - irregularly spaced ticks with long mantissas. This PR restores the default `plt.hist` behavior of showing five regularly-spaced ticks.