### PR TITLE
docs: fix some typos in the help

### DIFF
--- a/src/uproot_browser/tui/README.md
+++ b/src/uproot_browser/tui/README.md
@@ -13,7 +13,8 @@ and `h` to close a folder.
 
 Histograms, rectangular simple data (e.g. TTree's), and jagged arrays can
 be plotted. Click on an item or press `enter` to plot. If something can't
-be plotted, you'll see a scrollable error traceback.
+be plotted, you'll see a scrollable error traceback. If you think it should
+be plottable, feel free to open an issue. 2D plots are not yet supported.
 
 ## Themes
 
@@ -33,7 +34,8 @@ the help again.
 # Credits
 
 Uproot browser was created by Henry Schreiner and Aman Goel. It was rewritten
-by Elie Svoll and Jose Garcia to use the modern CSS-based Textaul library.
+by Elie Svoll and Jose Ayala Garcia to use the modern CSS-based Textual
+library.
 
 Uproot browser is made possible by the Scikit-HEP ecosystem, including uproot
 and awkward-array for data reading, hist and boost-histogram for computation.


### PR DESCRIPTION
Small typos fixed, and a little note about plots.
