### PR TITLE
fix: support Textual 0.24

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   hooks:
   - id: mypy
     files: src
-    additional_dependencies: [rich>=12, click>=8.1.1, hist, numpy, textual>0.18]
+    additional_dependencies: [rich>=12, click>=8.1.1, hist, numpy, textual>=0.24]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.4

--- a/src/uproot_browser/tui/left_panel.py
+++ b/src/uproot_browser/tui/left_panel.py
@@ -91,6 +91,7 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
             return
         if node.allow_expand and not node.is_expanded:
             node.expand()
+            # pylint: disable-next=no-value-for-parameter
             self.post_message(self.NodeExpanded(node))
 
     def action_cursor_out(self) -> None:
@@ -99,6 +100,7 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
             return
         if node.allow_expand and node.is_expanded:
             node.collapse()
+            # pylint: disable-next=no-value-for-parameter
             self.post_message(self.NodeCollapsed(node))
         elif (
             node.parent is not None
@@ -106,6 +108,7 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
             and node.parent.is_expanded
         ):
             node.parent.collapse()
+            # pylint: disable-next=no-value-for-parameter
             self.post_message(self.NodeCollapsed(node.parent))
             self.cursor_line = node.parent.line
             self.scroll_to_line(self.cursor_line)


### PR DESCRIPTION
"h" and "j" keys were broken.

Once we bump the minimum Textual (which might be soon due to the new overlay system!), then this extra workaround can be dropped.