### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.0.272"
   hooks:
     - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Committed via https://github.com/asottile/all-repos