### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ ignore = [
     "RUF001",  # Unicode chars
     "PLR",
 ]
-target-version = "py37"
 src = ["src"]
 typing-modules = ["uproot_browser._compat.typing"]
 unfixable = [


### PR DESCRIPTION
Seee https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos