### PR TITLE
specify default behavior to use "browse" if not recognized as subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pipx run uproot-browser
 
 uproot-browser currently provides the following features (get help with `-h` or `--help`, view the current version with `--version`):
 
-- `browse` can be used to display a TUI (text user interface).
+- `browse` can be used to display a TUI (text user interface), acts as default if no subcommand specified
 - `plot` can be used to display a plot.
 - `tree` can be used to display a tree.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = ["version"]
 dependencies = [
   'awkward >=1',
   'click >=8',
+  'click-default-group >=1.2',
   'hist >=2.4',
   'importlib_resources; python_version<"3.9"',
   'lz4',

--- a/src/uproot_browser/__main__.py
+++ b/src/uproot_browser/__main__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import click
+from click_default_group import DefaultGroup
 import uproot
 
 from ._version import version as __version__
@@ -19,7 +20,7 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 VERSION = __version__
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+@click.group(context_settings=CONTEXT_SETTINGS, cls=DefaultGroup, default='browse')
 @click.version_option(version=VERSION)
 def main() -> None:
     """
@@ -28,7 +29,7 @@ def main() -> None:
 
 
 @main.command()
-@click.argument("filename")
+@click.argument("filename", type=click.Path(exists=True))
 def tree(filename: str) -> None:
     """
     Display a tree.
@@ -53,7 +54,7 @@ def intercept(func: Callable[..., Any], *names: str) -> Callable[..., Any]:
 
 
 @main.command()
-@click.argument("filename")
+@click.argument("filename", type=click.Path(exists=True))
 @click.option(
     "--iterm", is_flag=True, help="Display an iTerm plot (requires [iterm] extra)."
 )
@@ -94,7 +95,7 @@ def plot(filename: str, iterm: bool) -> None:
 
 
 @main.command()
-@click.argument("filename")
+@click.argument("filename", type=click.Path(exists=True))
 def browse(filename: str) -> None:
     """
     Display a TUI.


### PR DESCRIPTION
Addresses #95,

This requires a new dependency, [on pypi](https://pypi.org/project/click-default-group/), since it modifies the args passed to the click group, discussion [here](https://github.com/pallets/click/issues/430)