### PR TITLE
fix: show the type that failed to plot

### DIFF
--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -42,7 +42,7 @@ def make_hist_title(item: Any, histogram: hist.Hist) -> str:
 
 
 @functools.singledispatch
-def plot(tree: Any) -> None:  # noqa: ARG001
+def plot(tree: Any) -> None:
     """
     Implement this for each type of plottable.
     """

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -46,7 +46,7 @@ def plot(tree: Any) -> None:  # noqa: ARG001
     """
     Implement this for each type of plottable.
     """
-    msg = "This object is not plottable yet"
+    msg = f"This object ({type(tree)}) is not plottable yet"
     raise RuntimeError(msg)
 
 


### PR DESCRIPTION
More info when something fails to plot (including if you dump with "d" so you can copy-paste it, etc).
