### PR TITLE
feat: tabbed left panel

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ def pylint(session: nox.Session) -> None:
     """
 
     session.install("-e.", "pylint", "matplotlib")
-    session.run("pylint", "src", *session.posargs)
+    session.run("pylint", "uproot_browser", *session.posargs)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,8 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-master.py-version = "3.9"
-master.jobs = "0"
+py-version = "3.9"
+jobs = "1"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 messages_control.enable = [

--- a/src/uproot_browser/tui/README.md
+++ b/src/uproot_browser/tui/README.md
@@ -9,6 +9,9 @@ something to plot. Press `spacebar` to open/close a directory or tree. You can
 also use the VIM keys: `j` to move down, `k` to move up, `l` to open a folder,
 and `h` to close a folder.
 
+You can also open the command palette with `ctrl-p`, which gives you some
+options like changing the theme, writing out an SVG, or quitting the program.
+
 ## Plotting
 
 Histograms, rectangular simple data (e.g. TTree's), and jagged arrays can
@@ -16,14 +19,18 @@ be plotted. Click on an item or press `enter` to plot. If something can't
 be plotted, you'll see a scrollable error traceback. If you think it should
 be plottable, feel free to open an issue. 2D plots are not yet supported.
 
-## Themes
+## Tools
 
-You can press `t` to toggle light and dark mode.
+The panel on the left (which can be hidden/shown with `b` has tabs; the `Tree`
+tab is the default, but you can also select `Tools`, which has a theme
+selector, and an Info tab, which gives the versions of installed packages.
+
 
 ## Leaving
 
-You can press `q` to quit. You can also press `d` to quit with a dump of the
-current plot and how to get the object being plotted in Python uproot code.
+You can press `q` or `esc` to quit. You can also press `d` to quit with a dump
+of the current plot and how to get the object being plotted in Python uproot
+code.
 
 ## Exiting the help.
 

--- a/src/uproot_browser/tui/browser.css
+++ b/src/uproot_browser/tui/browser.css
@@ -8,7 +8,7 @@ Browser Widget {
     scrollbar-size: 1 1;
 }
 
-#tree-view {
+#left-view {
     display: none;
     overflow: auto;
     width: 25%;
@@ -21,7 +21,7 @@ Tree > .tree--cursor {
     text-style: bold;
 }
 
-Browser.-show-tree #tree-view {
+Browser.-show-panel #left-view {
     display: block;
     max-width: 50%;
 }
@@ -48,6 +48,14 @@ ContentSwitcher#main-view {
 
 #empty {
     content-align: center middle;
+}
+
+Info {
+    overflow: scroll;
+}
+
+Tools {
+    overflow: scroll;
 }
 
 Footer > .footer--highlight {

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -46,6 +46,7 @@ from .right_panel import (
     PlotWidget,
     make_plot,
 )
+from .tools import Info, Tools
 
 
 class Browser(textual.app.App[object]):
@@ -58,13 +59,13 @@ class Browser(textual.app.App[object]):
         textual.binding.Binding("b", "toggle_files", "Navbar"),
         textual.binding.Binding("q", "quit", "Quit"),
         textual.binding.Binding("d", "quit_with_dump", "Dump & Quit"),
-        textual.binding.Binding("t", "toggle_theme", "Theme"),
         textual.binding.Binding("f1", "help", "Help"),
         textual.binding.Binding("?", "help", "Help", show=False),
         textual.binding.Binding("escape", "quit", "Quit", show=False),
     ]
 
     show_tree = var(True)
+    show_tools = var(False)
 
     def __init__(self, path: str, **kwargs: Any) -> None:
         self.path = path
@@ -78,8 +79,14 @@ class Browser(textual.app.App[object]):
         yield Header("uproot-browser")
         with textual.containers.Container():
             # left_panel
-            yield UprootTree(self.path, id="tree-view")
-            # right_panel
+            with textual.widgets.TabbedContent(id="left-view"):
+                with textual.widgets.TabPane("Tree"):
+                    yield UprootTree(self.path, id="tree-view")
+                with textual.widgets.TabPane("Tools"):
+                    yield Tools()
+                with textual.widgets.TabPane("Info"):
+                    yield Info()
+            # main_panel
             with textual.widgets.ContentSwitcher(id="main-view", initial="logo"):
                 yield LogoWidget(id="logo")
                 yield self.plot_widget
@@ -88,11 +95,11 @@ class Browser(textual.app.App[object]):
         yield textual.widgets.Footer()
 
     def on_mount(self, _event: textual.events.Mount) -> None:
-        self.query_one("#tree-view", UprootTree).focus()
+        self.query_one("#tree-view").focus()
 
     def watch_show_tree(self, show_tree: bool) -> None:
         """Called when show_tree is modified."""
-        self.set_class(show_tree, "-show-tree")
+        self.set_class(show_tree, "-show-panel")
 
     def action_help(self) -> None:
         self.push_screen(HelpScreen())
@@ -131,14 +138,10 @@ class Browser(textual.app.App[object]):
 
         self.exit(message=results)
 
-    def action_toggle_theme(self) -> None:
-        """An action to toggle dark mode."""
-        dark = self.theme != "textual-light"
-        theme = "textual-light" if dark else "textual-dark"
-
+    def watch_theme(self, _old: str, new: str) -> None:
+        dark = not new.endswith("-light")
         if self.plot_widget.item:
-            self.plot_widget.item.theme = "default" if dark else "dark"
-        self.theme = theme
+            self.plot_widget.item.theme = "dark" if dark else "default"
 
     def on_uproot_selected(self, message: UprootSelected) -> None:
         """A message sent by the tree when a file is clicked."""

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -79,14 +79,11 @@ class Browser(textual.app.App[object]):
             # left_panel
             yield UprootTree(self.path, id="tree-view")
             # right_panel
-            yield textual.widgets.ContentSwitcher(
-                LogoWidget(id="logo"),
-                self.plot_widget,
-                self.error_widget,
-                EmptyWidget(id="empty"),
-                id="main-view",
-                initial="logo",
-            )
+            with textual.widgets.ContentSwitcher(id="main-view", initial="logo"):
+                yield LogoWidget(id="logo")
+                yield self.plot_widget
+                yield self.error_widget
+                yield EmptyWidget(id="empty")
         yield textual.widgets.Footer()
 
     def on_mount(self, _event: textual.events.Mount) -> None:

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -61,6 +61,7 @@ class Browser(textual.app.App[object]):
         textual.binding.Binding("t", "toggle_theme", "Theme"),
         textual.binding.Binding("f1", "help", "Help"),
         textual.binding.Binding("?", "help", "Help", show=False),
+        textual.binding.Binding("escape", "quit", "Quit", show=False),
     ]
 
     show_tree = var(True)

--- a/src/uproot_browser/tui/help.py
+++ b/src/uproot_browser/tui/help.py
@@ -22,8 +22,7 @@ class HelpScreen(textual.screen.ModalScreen[None]):
         textual.binding.Binding("b", "", "Nothing", show=False),
         textual.binding.Binding("f1", "", "Nothing", show=False),
         textual.binding.Binding("q", "done", "Done", show=True),
-        textual.binding.Binding("esc", "done", "Done", show=True),
-        textual.binding.Binding("t", "toggle_theme", "Theme", show=True),
+        textual.binding.Binding("escape", "done", "Done", show=True),
     ]
 
     app: Browser
@@ -43,6 +42,3 @@ class HelpScreen(textual.screen.ModalScreen[None]):
 
     def action_done(self) -> None:
         self.app.pop_screen()
-
-    def action_toggle_theme(self) -> None:
-        self.app.action_toggle_theme()

--- a/src/uproot_browser/tui/tools.py
+++ b/src/uproot_browser/tui/tools.py
@@ -1,0 +1,30 @@
+import importlib.metadata
+
+import textual.containers
+import textual.widgets
+
+from .. import __version__
+
+
+class Tools(textual.containers.Container):
+    def compose(self) -> textual.app.ComposeResult:
+        yield textual.widgets.Label("Tools")
+        with textual.widgets.Collapsible(title="Theme", collapsed=False):
+            themes = self.app.available_themes
+            yield textual.widgets.Select([(t, t) for t in themes])
+
+    @textual.on(textual.widgets.Select.Changed)
+    def select_changed(self, event: textual.widgets.Select.Changed) -> None:
+        self.app.theme = str(event.value)
+
+
+class Info(textual.containers.Container):
+    def compose(self) -> textual.app.ComposeResult:
+        yield textual.widgets.Label("Info")
+        with textual.widgets.Collapsible(title="uproot-browser", collapsed=False):
+            yield textual.widgets.Label(f"Version: [green]{__version__}[/green]")
+        with textual.widgets.Collapsible(title="Packages", collapsed=False):
+            for dist in importlib.metadata.distributions():
+                yield textual.widgets.Label(
+                    f"{dist.metadata['Name']} == [green]{dist.version}[/green]"
+                )

--- a/src/uproot_browser/tui/tools.py
+++ b/src/uproot_browser/tui/tools.py
@@ -15,6 +15,7 @@ class Tools(textual.containers.Container):
 
     @textual.on(textual.widgets.Select.Changed)
     def select_changed(self, event: textual.widgets.Select.Changed) -> None:
+        # pylint: disable-next=attribute-defined-outside-init
         self.app.theme = str(event.value)
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -18,20 +18,6 @@ async def test_browse_plot() -> None:
         assert pilot.app.query_one("#main-view").current == "plot"
 
 
-async def test_theme_switch() -> None:
-    async with Browser(
-        skhep_testdata.data_path("uproot-Event.root")
-    ).run_test() as pilot:
-        await pilot.press("down", "down", "down", "enter")
-        browser_theme = pilot.app.theme
-        plot_theme = pilot.app.theme
-        await pilot.press("t")
-        new_browser_theme = pilot.app.theme
-        new_plot_theme = pilot.app.theme
-        assert browser_theme != new_browser_theme
-        assert plot_theme != new_plot_theme
-
-
 async def test_browse_empty() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-empty.root")


### PR DESCRIPTION
Inspired by the work of @eeelie in https://github.com/scikit-hep/uproot-browser/tree/feat/right-panel, but applying the idea to the left panel and adding tabs instead. Just some basic things here now, but hopefully this can become content aware and allow controls over the plot / data.

- **chore: use yield for content switcher**
- **fix: esc will also quit**
- **feat: add tabs for the left panel**

Stuck on a bug for a bit that was already fixed in https://github.com/scikit-hep/uproot-browser/pull/198 