### PR TITLE
fix: RNTuple tree structure

### DIFF
--- a/src/uproot_browser/tree.py
+++ b/src/uproot_browser/tree.py
@@ -56,7 +56,8 @@ def _(item: uproot.reading.ReadOnlyDirectory) -> Literal[True]:  # noqa: ARG001
     return True
 
 
-@is_dir.register
+@is_dir.register(uproot.behaviors.TBranch.HasBranches)
+@is_dir.register(uproot.behaviors.RNTuple.HasFields)
 def _(
     item: uproot.behaviors.TBranch.HasBranches | uproot.behaviors.RNTuple.HasFields,
 ) -> bool:


### PR DESCRIPTION
This PR fixes #209.

I also made some minor refactoring. For both TTrees and RNTuples `__len__` returns the number of top-level branches/fields, so those can be combined. Also, I switched from using `.keys()` to `.keys(recursive=False)`, which solves the issue for RNTuples and it might improve performance a tiny bit for TTrees since it's not finding all keys recursively. I did have to add an extra bit to make `mypy` happy, though.

I should add that the reason why this was happening was because paths in RNTuples are `.` separated instead of `/` separated.