### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
 
     - name: Install nox
       run: uv tool install nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-        - python-version: pypy-3.11
-          runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -69,7 +69,9 @@ def plot_branch(
     if len(finite) < 1:
         msg = f"Branch {tree.name} is empty."
         raise EmptyTreeError(msg)
-    histogram: hist.Hist[Any] = hist.numpy.histogram(finite, bins=width, histogram=hist.Hist)
+    histogram: hist.Hist[Any] = hist.numpy.histogram(
+        finite, bins=width, histogram=hist.Hist
+    )
     if expr:
         # pylint: disable-next=eval-used
         histogram = eval(expr, {"h": histogram})

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -34,8 +34,8 @@ def show() -> None:
 
 
 def make_hist_title(item: Any, histogram: hist.Hist[Any]) -> str:
-    inner_sum: float = float(np.sum(histogram.values()))
-    full_sum: float = float(np.sum(histogram.values(flow=True)))
+    inner_sum = float(np.sum(histogram.values()))
+    full_sum = float(np.sum(histogram.values(flow=True)))
 
     if math.isclose(inner_sum, full_sum):
         return f"{item.name} -- Entries: {inner_sum:g}"

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -33,9 +33,9 @@ def show() -> None:
     plt.show()
 
 
-def make_hist_title(item: Any, histogram: hist.Hist) -> str:
-    inner_sum: float = np.sum(histogram.values())
-    full_sum: float = np.sum(histogram.values(flow=True))
+def make_hist_title(item: Any, histogram: hist.Hist[Any]) -> str:
+    inner_sum: float = float(np.sum(histogram.values()))
+    full_sum: float = float(np.sum(histogram.values(flow=True)))
 
     if math.isclose(inner_sum, full_sum):
         return f"{item.name} -- Entries: {inner_sum:g}"
@@ -69,7 +69,7 @@ def plot_branch(
     if len(finite) < 1:
         msg = f"Branch {tree.name} is empty."
         raise EmptyTreeError(msg)
-    histogram: hist.Hist = hist.numpy.histogram(finite, bins=width, histogram=hist.Hist)
+    histogram: hist.Hist[Any] = hist.numpy.histogram(finite, bins=width, histogram=hist.Hist)
     if expr:
         # pylint: disable-next=eval-used
         histogram = eval(expr, {"h": histogram})

--- a/src/uproot_browser/plot_mpl.py
+++ b/src/uproot_browser/plot_mpl.py
@@ -31,7 +31,7 @@ def plot_branch(tree: uproot.TBranch) -> None:
     Plot a single tree branch.
     """
     array = tree.array()
-    histogram: hist.Hist = hist.numpy.histogram(
+    histogram: hist.Hist[Any] = hist.numpy.histogram(
         ak.flatten(array) if array.ndim > 1 else array, bins=50, histogram=hist.Hist
     )
     histogram.plot()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -26,6 +26,7 @@ async def test_browse_empty() -> None:
     ).run_test() as pilot:
         await pilot.press("down", "space", "down", "enter")
         await pilot.pause()
+        await pilot.pause()  # wait for thread worker to post EmptyMessage
         assert pilot.app.view_widget.item is None
 
 
@@ -35,6 +36,7 @@ async def test_browse_empty_vim() -> None:
     ).run_test() as pilot:
         await pilot.press("j", "l", "j", "enter")
         await pilot.pause()
+        await pilot.pause()  # wait for thread worker to post EmptyMessage
         assert pilot.app.view_widget.item is None
 
 


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos