### PR TITLE
fix(tui): re-render plots and sync theme selector on theme change

### DIFF
--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -4,6 +4,7 @@ if not __package__:
     __package__ = "uproot_browser.tui"  # pylint: disable=redefined-builtin
 
 import contextlib
+import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import plotext as plt
@@ -99,10 +100,6 @@ class Browser(textual.app.App[object]):
         """Called in response to key binding."""
         self.show_tree = not self.show_tree
 
-    @staticmethod
-    def _is_dark(theme: str) -> bool:
-        return not theme.endswith(("-light", "-latte", "-ansi"))
-
     def action_quit_with_dump(self) -> None:
         """Dump the current state of the application."""
 
@@ -117,7 +114,7 @@ class Browser(textual.app.App[object]):
             )
             items = [self.view_widget.item]
 
-        theme = "ansi_dark" if self._is_dark(self.theme) else "ansi_light"
+        theme = "ansi_dark" if self.current_theme.dark else "ansi_light"
 
         results = rich.console.Group(
             *items,
@@ -126,14 +123,19 @@ class Browser(textual.app.App[object]):
 
         self.exit(message=results)
 
-    def watch_theme(self, _old: str, new: str) -> None:
+    def watch_theme(self) -> None:
         if isinstance(self.view_widget.item, Plotext):
-            self.view_widget.item.theme = "dark" if self._is_dark(new) else "default"
+            theme = "dark" if self.current_theme.dark else "default"
+            # Reassign (rather than mutate) so that watchers fire and the
+            # cached canvas is invalidated.
+            self.view_widget.item = dataclasses.replace(
+                self.view_widget.item, theme=theme, previous=None
+            )
 
     def on_uproot_selected(self, message: UprootSelected) -> None:
         """A message sent by the tree when a file is clicked."""
 
-        theme = "dark" if self._is_dark(self.theme) else "default"
+        theme = "dark" if self.current_theme.dark else "default"
         self.view_widget.plot_input.value = ""
         self.view_widget.item = Plotext(message.upfile, message.path, theme, self)
 

--- a/src/uproot_browser/tui/tools.py
+++ b/src/uproot_browser/tui/tools.py
@@ -1,7 +1,9 @@
 import importlib.metadata
 
+import textual.app
 import textual.containers
 import textual.widgets
+from textual.theme import Theme
 
 from .. import __version__
 
@@ -10,13 +12,21 @@ class Tools(textual.containers.Container):
     def compose(self) -> textual.app.ComposeResult:
         with textual.widgets.Collapsible(title="Theme", collapsed=False):
             themes = self.app.available_themes
-            yield textual.widgets.Select([(t, t) for t in themes], allow_blank=False)
+            yield textual.widgets.Select(
+                [(t, t) for t in themes], allow_blank=False, value=self.app.theme
+            )
         with (
             textual.widgets.Collapsible(title="Plot", collapsed=False),
             textual.containers.Horizontal(),
         ):
             yield textual.widgets.Label("Entry box")
             yield textual.widgets.Switch()
+
+    def on_mount(self) -> None:
+        self.app.theme_changed_signal.subscribe(self, self._on_theme_change)
+
+    def _on_theme_change(self, theme: Theme) -> None:
+        self.query_one(textual.widgets.Select).value = theme.name
 
     @textual.on(textual.widgets.Switch.Changed)
     def switch_changed(self, event: textual.widgets.Switch.Changed) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,4 +1,5 @@
 import skhep_testdata
+import textual.widgets
 
 from uproot_browser.tui.browser import Browser
 from uproot_browser.tui.plot import Plotext
@@ -38,6 +39,39 @@ async def test_browse_empty_vim() -> None:
         await pilot.pause()
         await pilot.pause()  # wait for thread worker to post EmptyMessage
         assert pilot.app.view_widget.item is None
+
+
+async def test_theme_switch_updates_plot() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        await pilot.press("down", "down", "down", "enter")
+        await pilot.pause()
+        await pilot.pause()
+        item_before = pilot.app.view_widget.item
+        assert isinstance(item_before, Plotext)
+        assert item_before.theme == "dark"
+
+        pilot.app.theme = "textual-light"
+        await pilot.pause()
+        await pilot.pause()
+        item_after = pilot.app.view_widget.item
+        assert isinstance(item_after, Plotext)
+        # the item must be replaced, not mutated, so the plot re-renders
+        assert item_after is not item_before
+        assert item_after.theme == "default"
+
+
+async def test_theme_select_tracks_theme() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        select = pilot.app.query_one(textual.widgets.Select)
+        assert select.value == pilot.app.theme
+
+        pilot.app.theme = "nord"
+        await pilot.pause()
+        assert select.value == "nord"
 
 
 async def test_help_focus() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

Two theme bugs, both verified with pilot tests (included as regression tests):

- **Switching themes never updated an existing plot.** `watch_theme` mutated `view_widget.item.theme`, but the plot actually displayed is a `dataclasses.replace` copy produced by the threaded worker, so the visible plot kept the old plotext theme and its cached canvas — even across resizes. The watcher now *reassigns* the item with `previous=None`, so `watch_item` fires and the plot re-renders in the new theme.
- **The Tools theme `Select` always showed the first theme**, not the current one. It now starts on `app.theme` and subscribes to `theme_changed_signal` to stay in sync.

Also replaces the `_is_dark` theme-name suffix heuristic (`-light`/`-latte`/`-ansi`) with the authoritative `self.current_theme.dark`.

Tested against textual 8.2.7 and the 0.86 floor pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)