### PR TITLE
fix(tui): include plot expression in Dump & Quit output

### DIFF
--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -115,6 +115,10 @@ class Browser(textual.app.App[object]):
             msg += (
                 f'\nitem = uproot_file["{self.view_widget.item.selection.lstrip("/")}"]'
             )
+            if self.view_widget.item.expr:
+                msg += (
+                    f"\n# plotted histogram h sliced with: {self.view_widget.item.expr}"
+                )
             items = [self.view_widget.item]
 
         theme = "ansi_dark" if self._is_dark(self.theme) else "ansi_light"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

`d` (Dump & Quit) prints Python code to reproduce the current plot, but it omitted the expression typed into the plot input box, so a sliced plot (e.g. `h[50:]`) could not be reproduced from the dump. The expression is now included as a comment alongside the item lookup.

(Emitting full runnable `hist` code for the expression would need per-type code generation — happy to do that as a follow-up if preferred.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)