### PR TITLE
refactor(tui): drop old-textual compat shims and duplicate tree messages

### DIFF
--- a/src/uproot_browser/tui/left_panel.py
+++ b/src/uproot_browser/tui/left_panel.py
@@ -21,9 +21,7 @@ if TYPE_CHECKING:
 class UprootTree(textual.widgets.Tree[UprootEntry]):
     """currently just extending DirectoryTree, showing current path"""
 
-    BINDINGS: ClassVar[
-        list[textual.binding.Binding | tuple[str, str] | tuple[str, str, str]]
-    ] = [
+    BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
         textual.binding.Binding("h", "cursor_out", "Cursor out", show=False),
         textual.binding.Binding("j", "cursor_down", "Cursor Down", show=False),
         textual.binding.Binding("k", "cursor_up", "Cursor Up", show=False),
@@ -72,7 +70,7 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
             self.post_message(UprootSelected(self.upfile, item.path))
 
     def on_tree_node_expanded(
-        self, event: textual.widgets.Tree.NodeSelected[UprootEntry]
+        self, event: textual.widgets.Tree.NodeExpanded[UprootEntry]
     ) -> None:
         event.stop()
         item = event.node.data
@@ -80,31 +78,12 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
         if item.is_dir:
             self.load_directory(event.node)
 
-    def _node_expanded(
-        self, node: textual.widgets.tree.TreeNode[UprootEntry]
-    ) -> textual.widgets.Tree.NodeExpanded[UprootEntry]:
-        try:
-            return self.NodeExpanded(node)
-        except TypeError:  # textual 0.24-0.26
-            # pylint: disable-next=too-many-function-args
-            return self.NodeExpanded(self, node)  # type:ignore[call-arg,arg-type]
-
-    def _node_collapsed(
-        self, node: textual.widgets.tree.TreeNode[UprootEntry]
-    ) -> textual.widgets.Tree.NodeCollapsed[UprootEntry]:
-        try:
-            return self.NodeCollapsed(node)
-        except TypeError:  # textual 0.24-0.26
-            # pylint: disable-next=too-many-function-args
-            return self.NodeCollapsed(self, node)  # type:ignore[call-arg,arg-type]
-
     def action_cursor_in(self) -> None:
         node = self.cursor_node
         if node is None:
             return
         if node.allow_expand and not node.is_expanded:
             node.expand()
-            self.post_message(self._node_expanded(node))
 
     def action_cursor_out(self) -> None:
         node = self.cursor_node
@@ -112,13 +91,11 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
             return
         if node.allow_expand and node.is_expanded:
             node.collapse()
-            self.post_message(self._node_collapsed(node))
         elif (
             node.parent is not None
             and node.parent.allow_expand
             and node.parent.is_expanded
         ):
             node.parent.collapse()
-            self.post_message(self._node_collapsed(node))
             self.cursor_line = node.parent.line
             self.scroll_to_line(self.cursor_line)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

- `_node_expanded`/`_node_collapsed` worked around a message-constructor signature change in textual 0.24–0.26; with the floor at `>=0.86` they are dead code.
- `TreeNode.expand()`/`collapse()` post `NodeExpanded`/`NodeCollapsed` themselves (verified on both 0.86 and 8.2.7), so the manual `post_message` calls in the vim-style `l`/`h` actions sent **duplicate** messages each press (harmless only because `load_directory` guards on existing children). The previous code also posted the *child* node in the parent-collapse branch; the message now correctly carries the parent.
- Fixes the event annotation on `on_tree_node_expanded` (was `NodeSelected`) and uses the `textual.binding.BindingType` alias for `BINDINGS`.

Suite passes on textual 8.2.7 and the 0.86 floor (the vim-navigation test covers these actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)