### PR TITLE
perf(tui): lazy-load the Tools and Info tabs

### DIFF
--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -12,6 +12,7 @@ import textual.app
 import textual.binding
 import textual.containers
 import textual.events
+import textual.lazy
 import textual.widgets
 import textual.worker
 from textual.reactive import var
@@ -77,9 +78,9 @@ class Browser(textual.app.App[object]):
                 with textual.widgets.TabPane("Tree"):
                     yield UprootTree(self.path, id="tree-view")
                 with textual.widgets.TabPane("Tools"):
-                    yield Tools()
+                    yield textual.lazy.Lazy(Tools())
                 with textual.widgets.TabPane("Info"):
-                    yield Info()
+                    yield textual.lazy.Lazy(Info())
             # main_panel
             yield self.view_widget
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

All three left-panel tabs composed eagerly at startup. The Info tab in particular iterates `importlib.metadata.distributions()` — a scan of all of site-packages — and creates one `Static` per installed package, all before the first paint. In a fat environment that's a noticeable startup delay.

Wrapping the two hidden tabs' contents in `textual.lazy.Lazy` (the pattern the Textual docs recommend for `TabbedContent`) defers their mounting until after the first screen refresh, so the tree appears immediately. The Tree tab stays eager since it's the initial, focused tab.

Tested on textual 8.2.7 and the 0.86 floor pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)