### PR TITLE
fix(plot): pass bin centers to plotext bar

### DIFF
--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -76,11 +76,11 @@ def plot_branch(
         # pylint: disable-next=eval-used
         histogram = eval(expr, {"h": histogram})
     plt.bar(
-        histogram.axes[0].edges,
+        histogram.axes[0].centers,
         histogram.values().astype(float),
     )
     plt.ylim(lower=0)
-    plt.xticks(np.linspace(histogram.axes[0][0][0], histogram.axes[0][-1][-1], 5))
+    plt.xticks(np.linspace(histogram.axes[0].edges[0], histogram.axes[0].edges[-1], 5))
     plt.xlabel(histogram.axes[0].name)
     plt.title(make_hist_title(tree, histogram))
 
@@ -91,6 +91,7 @@ plot.register(uproot.models.RNTuple.RField)(plot_branch)  # type: ignore[no-unty
 @plot.register
 def plot_hist(
     tree: uproot.behaviors.TH1.Histogram,
+    *,
     width: int = 100,  # noqa: ARG001
     expr: str = "",
 ) -> None:
@@ -101,8 +102,8 @@ def plot_hist(
     if expr:
         # pylint: disable-next=eval-used
         histogram = eval(expr, {"h": histogram})
-    plt.bar(histogram.axes[0].edges, histogram.values().astype(float))
+    plt.bar(histogram.axes[0].centers, histogram.values().astype(float))
     plt.ylim(lower=0)
-    plt.xticks(np.linspace(histogram.axes[0][0][0], histogram.axes[0][-1][-1], 5))
+    plt.xticks(np.linspace(histogram.axes[0].edges[0], histogram.axes[0].edges[-1], 5))
     plt.xlabel(histogram.axes[0].name)
     plt.title(make_hist_title(tree, histogram))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

`plt.bar(histogram.axes[0].edges, histogram.values()...)` passes N+1 x positions with N heights — plotext happens to tolerate the mismatch, but the pairing was accidental. Bin centers are the correct x coordinates and match lengths exactly.

Also:
- The xtick range now uses `axes[0].edges[0]` / `.edges[-1]` instead of the equivalent-but-cryptic `axes[0][0][0]` / `axes[0][-1][-1]`.
- `plot_hist`'s optional arguments are now keyword-only, matching `plot_branch` and the generic dispatch signature.

Verified by rendering both a TH1 (`hstat`) and a branch (`T/event/fNtrack`) from `uproot-Event.root` via `uproot-browser plot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)