### PR TITLE
chore: remove dead Footer CSS, stale lint ignore, and small cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
@@ -151,6 +150,5 @@ flake8-boolean-trap.extend-allowed-calls = ["textual.reactive.var"]
 "noxfile.py" = ["T20"]
 "tests/*" = ["T20", "INP001"]
 "docs/*" = ["INP001"]
-"src/uproot_browser/tree.py" = ["UP006"]
 "src/uproot_browser/__main__.py" = ["PLC0415"]    # Import outside toplevel
 "src/uproot_browser/tui/browser.py" = ["SLF001"]  # Have to access private var in plt

--- a/src/uproot_browser/__main__.py
+++ b/src/uproot_browser/__main__.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import functools
 import os
-import typing
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -19,9 +18,7 @@ if TYPE_CHECKING:
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
-VERSION = __version__
-
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     DefaultGroup = click.Group
 else:
     from click_default_group import DefaultGroup
@@ -43,7 +40,7 @@ def get_testdata(filename: str, *, testdata: bool) -> str:
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, cls=DefaultGroup, default="browse")
-@click.version_option(version=VERSION)
+@click.version_option(version=__version__)
 def main() -> None:
     """
     Must provide a subcommand.

--- a/src/uproot_browser/tui/browser.css
+++ b/src/uproot_browser/tui/browser.css
@@ -92,20 +92,6 @@ CollapsibleTitle {
    text-style: bold;
 }
 
-Footer > .footer--highlight {
-    background: $secondary-darken-2;
-}
-
-Footer > .footer--key {
-    text-style: bold;
-    background: $secondary-darken-3;
-}
-
-Footer > .footer--highlight-key {
-    background: $secondary-darken-2;
-    text-style: bold;
-}
-
 Footer {
     background: $secondary-lighten-2;
 }

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -45,13 +45,11 @@ if TYPE_CHECKING:
     from .messages import ErrorMessage, RequestPlot, UprootSelected
 
 
-class Browser(textual.app.App[object]):
+class Browser(textual.app.App[None]):
     """A basic implementation of the uproot-browser TUI"""
 
     CSS_PATH = "browser.css"
-    BINDINGS: ClassVar[
-        list[textual.binding.Binding | tuple[str, str] | tuple[str, str, str]]
-    ] = [
+    BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
         textual.binding.Binding("b", "toggle_files", "Navbar"),
         textual.binding.Binding("q", "quit", "Quit"),
         textual.binding.Binding("d", "quit_with_dump", "Dump & Quit"),

--- a/src/uproot_browser/tui/help.py
+++ b/src/uproot_browser/tui/help.py
@@ -15,9 +15,7 @@ if typing.TYPE_CHECKING:
 
 
 class HelpScreen(textual.screen.ModalScreen[None]):
-    BINDINGS: ClassVar[
-        list[textual.binding.Binding | tuple[str, str] | tuple[str, str, str]]
-    ] = [
+    BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
         textual.binding.Binding("d", "", "Nothing", show=False),
         textual.binding.Binding("b", "", "Nothing", show=False),
         textual.binding.Binding("f1", "", "Nothing", show=False),
@@ -38,7 +36,7 @@ class HelpScreen(textual.screen.ModalScreen[None]):
         self.query_one("#help-text", textual.widgets.MarkdownViewer).focus()
 
     def on_button_pressed(self, _event: textual.widgets.Button.Pressed) -> None:
-        self.app.pop_screen()
+        self.dismiss()
 
     def action_done(self) -> None:
-        self.app.pop_screen()
+        self.dismiss()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #233.

- **Dead Footer CSS**: Textual's Footer rewrite renamed its component classes to `footer-key--key`/`footer-key--description` on `FooterKey`, so the `Footer > .footer--key` / `.footer--highlight` / `.footer--highlight-key` rules silently matched nothing on every version the `>=0.86` pin allows. Removed (the plain `Footer { background: ... }` rule still applies). If the old key styling is wanted back, it would need porting to the new component classes — happy to do that instead.
- **Stale ruff ignore**: `tree.py` passes `UP006` without the per-file ignore (verified with `ruff check --isolated`).
- **pyproject**: the BSD license classifier was listed twice.
- **`__main__.py`**: drop the `VERSION = __version__` alias and the mixed `import typing` / `from typing import ...` style.
- **TUI typing/API polish**: `HelpScreen` uses `self.dismiss()` instead of `app.pop_screen()`, `BINDINGS` annotations use the `textual.binding.BindingType` alias, and `Browser` is `App[None]`.

Suite passes on textual 8.2.7 and the 0.86 floor pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)