### PR TITLE
fix(tests): activate Tools tab before querying Select in theme test

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -66,6 +66,9 @@ async def test_theme_select_tracks_theme() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
+        # Tools tab is lazy-loaded; activate it first so Select is mounted
+        pilot.app.query_one("#left-view", textual.widgets.TabbedContent).active = "tab-2"
+        await pilot.pause()
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -67,7 +67,9 @@ async def test_theme_select_tracks_theme() -> None:
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
         # Tools tab is lazy-loaded; activate it first so Select is mounted
-        pilot.app.query_one("#left-view", textual.widgets.TabbedContent).active = "tab-2"
+        pilot.app.query_one(
+            "#left-view", textual.widgets.TabbedContent
+        ).active = "tab-2"
         await pilot.pause()
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -71,6 +71,7 @@ async def test_theme_select_tracks_theme() -> None:
             "#left-view", textual.widgets.TabbedContent
         ).active = "tab-2"
         await pilot.pause()
+        await pilot.pause()  # second pause lets the lazy content finish mounting
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `test_theme_select_tracks_theme` was broken by the interaction of two recent PRs: #238 (lazy-load Tools/Info tabs) and #234 (sync theme `Select` on theme change)
- The `Select` widget lives inside the lazily-loaded Tools tab and is not mounted until that tab is activated — so `query_one(Select)` raised `NoMatches`
- Fix: activate the Tools tab (`tab-2`) and `await pilot.pause()` before querying, so the lazy content is mounted first

## Test plan

- [x] `uv run pytest` passes (9/9)