### PR TITLE
test(tui): fix flaky Windows theme Select test

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,8 +1,28 @@
+from collections.abc import Callable
+
 import skhep_testdata
+import textual.pilot
 import textual.widgets
 
 from uproot_browser.tui.browser import Browser
 from uproot_browser.tui.plot import Plotext
+
+
+async def wait_until(
+    pilot: textual.pilot.Pilot[None],
+    predicate: Callable[[], bool],
+    *,
+    tries: int = 100,
+) -> None:
+    """Pump the event loop until predicate holds (or give up after `tries`).
+
+    Lazy-mounted widgets can take a variable number of message cycles to settle,
+    especially on slower CI runners, so poll instead of guessing a pause count.
+    """
+    for _ in range(tries):
+        if predicate():
+            return
+        await pilot.pause()
 
 
 async def test_browse_logo() -> None:
@@ -70,13 +90,20 @@ async def test_theme_select_tracks_theme() -> None:
         pilot.app.query_one(
             "#left-view", textual.widgets.TabbedContent
         ).active = "tab-2"
-        await pilot.pause()
-        await pilot.pause()  # second pause lets the lazy content finish mounting
+        # Lazy mount takes a variable number of cycles; wait for it to settle.
+        await wait_until(
+            pilot,
+            lambda: (
+                bool(pilot.app.query(textual.widgets.Select))
+                and pilot.app.query_one(textual.widgets.Select).value
+                != textual.widgets.Select.BLANK
+            ),
+        )
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme
 
         pilot.app.theme = "nord"
-        await pilot.pause()
+        await wait_until(pilot, lambda: select.value == "nord")
         assert select.value == "nord"
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`test_theme_select_tracks_theme` flakes on Windows CI ([recent main run](https://github.com/scikit-hep/uproot-browser/actions/runs/27457698153)):

```
>           assert select.value == pilot.app.theme
E           AssertionError: assert Select.NULL == 'textual-dark'
```

The test activates the lazily-loaded Tools tab, then waited a fixed **two** `pilot.pause()` cycles before asserting the theme `Select`'s value. On slower Windows runners the lazily-mounted `Select` hasn't settled its value within those two cycles, so it's still the unset `Select.BLANK` sentinel (repr `Select.NULL`). Guessing a pause count is inherently racy.

## Fix

- Add a `wait_until(pilot, predicate)` helper that pumps the event loop until a condition holds (bounded by `tries`), instead of guessing how many message cycles a lazy mount needs.
- Poll until the `Select` is mounted with a non-`BLANK` value before the first assert, and until the value reflects the theme change before the second.

This waits exactly as long as needed rather than a fixed count, so it's robust to runner speed.

## Verification

- `prek -a` clean
- Full `tests/test_tui.py` suite passes
- Formerly-flaky test passed 15/15 in a local stress loop