### PR TITLE
test(tui): fix second Windows theme-test flake (signal subscription race)

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -6,6 +6,7 @@ import textual.widgets
 
 from uproot_browser.tui.browser import Browser
 from uproot_browser.tui.plot import Plotext
+from uproot_browser.tui.tools import Tools
 
 
 async def wait_until(
@@ -23,6 +24,13 @@ async def wait_until(
         if predicate():
             return
         await pilot.pause()
+
+
+def subscribed(pilot: textual.pilot.Pilot[None], widget_type: type) -> bool:
+    """True once a widget of `widget_type` is subscribed to the theme signal."""
+    widgets = pilot.app.query(widget_type)
+    subscriptions = pilot.app.theme_changed_signal._subscriptions  # noqa: SLF001
+    return any(widget in subscriptions for widget in widgets)
 
 
 async def test_browse_logo() -> None:
@@ -86,19 +94,15 @@ async def test_theme_select_tracks_theme() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
-        # Tools tab is lazy-loaded; activate it first so Select is mounted
+        # Tools tab is lazy-loaded; activate it so the Tools widget mounts.
         pilot.app.query_one(
             "#left-view", textual.widgets.TabbedContent
         ).active = "tab-2"
-        # Lazy mount takes a variable number of cycles; wait for it to settle.
-        await wait_until(
-            pilot,
-            lambda: (
-                bool(pilot.app.query(textual.widgets.Select))
-                and pilot.app.query_one(textual.widgets.Select).value
-                != textual.widgets.Select.BLANK
-            ),
-        )
+        # Tools tracks the theme via a signal it subscribes to in on_mount. The
+        # Select's value is set earlier (in compose), so waiting only for the
+        # Select to mount races the subscription: a theme change in between is
+        # missed. Wait for the subscription itself, the real precondition.
+        await wait_until(pilot, lambda: subscribed(pilot, Tools))
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

After #243, `test_theme_select_tracks_theme` still flaked on Windows CI ([run](https://github.com/scikit-hep/uproot-browser/actions/runs/27554735595)) — but now at the **second** assertion:

```
>           assert select.value == "nord"
E           AssertionError: assert 'textual-dark' == 'nord'
```

The value never reached `nord`, even with polling, so this isn't a "needs more cycles" timing issue — the theme change was simply never delivered to the Select.

## Root cause

`Tools` tracks the theme by subscribing to `app.theme_changed_signal` in its `on_mount`. But the Select's *value* is set earlier, in `compose`. #243's wait returned as soon as the Select had a non-`BLANK` value — which can happen **before** `Tools.on_mount` runs and registers the subscription. On a slow runner the test then set `app.theme = "nord"` during that gap, the signal published with no subscriber, and the Select stayed at its initial value forever.

## Fix

Wait for the actual precondition — the `Tools` widget being subscribed to the theme signal — before changing the theme, via a small `subscribed()` helper. Once subscribed, the existing poll on `select.value == "nord"` is reliable.

## Verification

- `prek -a` clean
- Full `tests/test_tui.py` suite passes
- Test passed 10/10 in a local stress loop