### PR TITLE
refactor(tui): track theme via reactive watch instead of a signal

### DIFF
--- a/src/uproot_browser/tui/tools.py
+++ b/src/uproot_browser/tui/tools.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 import importlib.metadata
-from typing import TYPE_CHECKING
 
 import textual.app
 import textual.containers
 import textual.widgets
 
 from .. import __version__
-
-if TYPE_CHECKING:
-    from textual.theme import Theme
 
 
 class Tools(textual.containers.Container):
@@ -28,10 +24,13 @@ class Tools(textual.containers.Container):
             yield textual.widgets.Switch()
 
     def on_mount(self) -> None:
-        self.app.theme_changed_signal.subscribe(self, self._on_theme_change)
+        # Keep the Select in sync with the app theme. init=True syncs the value
+        # immediately, so this also catches a theme set before this lazy widget
+        # mounted — no race between mounting and tracking.
+        self.watch(self.app, "theme", self._sync_theme)
 
-    def _on_theme_change(self, theme: Theme) -> None:
-        self.query_one(textual.widgets.Select).value = theme.name
+    def _sync_theme(self, theme: str) -> None:
+        self.query_one(textual.widgets.Select).value = theme
 
     @textual.on(textual.widgets.Switch.Changed)
     def switch_changed(self, event: textual.widgets.Switch.Changed) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -6,7 +6,6 @@ import textual.widgets
 
 from uproot_browser.tui.browser import Browser
 from uproot_browser.tui.plot import Plotext
-from uproot_browser.tui.tools import Tools
 
 
 async def wait_until(
@@ -24,13 +23,6 @@ async def wait_until(
         if predicate():
             return
         await pilot.pause()
-
-
-def subscribed(pilot: textual.pilot.Pilot[None], widget_type: type) -> bool:
-    """True once a widget of `widget_type` is subscribed to the theme signal."""
-    widgets = pilot.app.query(widget_type)
-    subscriptions = pilot.app.theme_changed_signal._subscriptions  # noqa: SLF001
-    return any(widget in subscriptions for widget in widgets)
 
 
 async def test_browse_logo() -> None:
@@ -94,15 +86,19 @@ async def test_theme_select_tracks_theme() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
-        # Tools tab is lazy-loaded; activate it so the Tools widget mounts.
+        # Tools tab is lazy-loaded; activate it so the Select mounts and starts
+        # tracking the theme (Tools.on_mount sets up the watcher).
         pilot.app.query_one(
             "#left-view", textual.widgets.TabbedContent
         ).active = "tab-2"
-        # Tools tracks the theme via a signal it subscribes to in on_mount. The
-        # Select's value is set earlier (in compose), so waiting only for the
-        # Select to mount races the subscription: a theme change in between is
-        # missed. Wait for the subscription itself, the real precondition.
-        await wait_until(pilot, lambda: subscribed(pilot, Tools))
+        await wait_until(
+            pilot,
+            lambda: (
+                bool(pilot.app.query(textual.widgets.Select))
+                and pilot.app.query_one(textual.widgets.Select).value
+                != textual.widgets.Select.BLANK
+            ),
+        )
         select = pilot.app.query_one(textual.widgets.Select)
         assert select.value == pilot.app.theme
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Background

The theme `Select` in the Tools tab flaked twice on Windows CI (#243, #245). Both were timing fixes in the test; this PR removes the underlying cause in the source.

## Problem

`Tools` kept the `Select` in sync with the app theme by subscribing to `theme_changed_signal` in `on_mount`, while the Select's *value* was set separately in `compose`. That split is racy: the tab is lazily mounted, and a theme change in the window between the Select mounting and `on_mount` registering the subscription is silently lost. That's what flaked on the slower Windows runners.

## Fix

Replace the signal subscription with Textual's `DOMNode.watch` on the app's `theme` reactive:

```python
def on_mount(self) -> None:
    self.watch(self.app, "theme", self._sync_theme)

def _sync_theme(self, theme: str) -> None:
    self.query_one(textual.widgets.Select).value = theme
```

`watch(..., init=True)` (the default) fires immediately with the *current* value when the watcher is established, so even a theme set before this lazy widget mounts is caught up — the mount/track race is gone at the source. The callback also receives the theme name (`str`) directly, dropping the `Theme` import.

This makes the `subscribed()` test helper added in #245 unnecessary, so it's removed and `test_theme_select_tracks_theme` is simplified back to just waiting for the Select to mount.

## Verification

- Demonstrated the race is gone: changing the theme in the same tick as activating the tab (before `Tools` mounts) still ends with the Select showing the new theme.
- `prek -a` clean, full `tests/test_tui.py` suite passes, test passed 8/8 in a local stress loop.