### PR TITLE
feat(tui): emit runnable hist code for plot expression in Dump & Quit

### DIFF
--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -65,7 +65,9 @@ def plot_branch(
     """
     Plot a single tree branch.
     """
-    if isinstance(tree.interpretation, uproot.interpretation.objects.AsObjects):
+    # RField has no `interpretation`; it is always read as an array.
+    interpretation = getattr(tree, "interpretation", None)
+    if isinstance(interpretation, uproot.interpretation.objects.AsObjects):
         arr = tree.array(library="np")
         if len(arr) == 0:
             msg = f"Branch {tree.name} is empty."
@@ -120,7 +122,9 @@ def dump_branch(
     """
     Source for rebuilding a single tree branch as a histogram.
     """
-    if isinstance(tree.interpretation, uproot.interpretation.objects.AsObjects):
+    # RField has no `interpretation`; it is always read as an array.
+    interpretation = getattr(tree, "interpretation", None)
+    if isinstance(interpretation, uproot.interpretation.objects.AsObjects):
         return (
             "import functools\n"
             "import operator\n"

--- a/src/uproot_browser/plot.py
+++ b/src/uproot_browser/plot.py
@@ -99,6 +99,60 @@ def plot_branch(
 plot.register(uproot.models.RNTuple.RField)(plot_branch)  # type: ignore[no-untyped-call]
 
 
+@functools.singledispatch
+def dump(tree: Any, *, width: int = 100) -> str:  # noqa: ARG001
+    """
+    Return standalone Python source that rebuilds the plotted histogram as ``h``
+    from an object bound to ``item``. Mirrors :func:`plot` for the "Dump & Quit"
+    output. Implement this for each type of plottable.
+    """
+    msg = f"This object ({type(tree)}) is not plottable yet"
+    raise RuntimeError(msg)
+
+
+# Simpler in Python 3.11+
+@dump.register(uproot.TBranch)
+def dump_branch(
+    tree: uproot.TBranch | uproot.models.RNTuple.RField,
+    *,
+    width: int = 100,
+) -> str:
+    """
+    Source for rebuilding a single tree branch as a histogram.
+    """
+    if isinstance(tree.interpretation, uproot.interpretation.objects.AsObjects):
+        return (
+            "import functools\n"
+            "import operator\n"
+            'arr = item.array(library="np")\n'
+            "h = functools.reduce(operator.add, [x.to_hist() for x in arr])"
+        )
+    return (
+        "import awkward as ak\n"
+        "import hist\n"
+        "import numpy as np\n"
+        "array = item.array()\n"
+        "values = ak.flatten(array) if array.ndim > 1 else array\n"
+        "finite = values[np.isfinite(values)]\n"
+        f"h = hist.numpy.histogram(finite, bins={width}, histogram=hist.Hist)"
+    )
+
+
+dump.register(uproot.models.RNTuple.RField)(dump_branch)  # type: ignore[no-untyped-call]
+
+
+@dump.register
+def dump_hist(
+    tree: uproot.behaviors.TH1.Histogram,  # noqa: ARG001
+    *,
+    width: int = 100,  # noqa: ARG001
+) -> str:
+    """
+    Source for rebuilding a 1-D histogram.
+    """
+    return "import hist\nh = hist.Hist(item.to_hist())"
+
+
 @plot.register
 def plot_hist(
     tree: uproot.behaviors.TH1.Histogram,

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -35,13 +35,11 @@ with contextlib.suppress(AttributeError):
     plt._dict.themes["dark"][2] = dark_text
 
 
-import uproot_browser.plot
-
 from .error import Error
 from .header import Header
 from .help import HelpScreen
 from .left_panel import UprootTree
-from .plot import Plotext, apply_selection
+from .plot import Plotext, apply_selection, dump
 from .tools import Info, Tools
 from .viewer import ViewWidget
 
@@ -113,11 +111,9 @@ class Browser(textual.app.App[None]):
             plotext = self.view_widget.item
             msg += f'\nitem = uproot_file["{plotext.selection.lstrip("/")}"]'
             *_, selected = apply_selection(plotext.upfile, plotext.selection.split(":"))
-            width = (plotext.size[0] - 5) * 4 if plotext.size else 100
+            size = plotext.size or ()
             with contextlib.suppress(RuntimeError):
-                msg += f"\n{uproot_browser.plot.dump(selected, width=width)}"
-                if plotext.expr:
-                    msg += f"\nh = {plotext.expr}"
+                msg += f"\n{dump(selected, *size, expr=plotext.expr)}"
             items = [plotext]
 
         theme = "ansi_dark" if self.current_theme.dark else "ansi_light"

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -35,11 +35,13 @@ with contextlib.suppress(AttributeError):
     plt._dict.themes["dark"][2] = dark_text
 
 
+import uproot_browser.plot
+
 from .error import Error
 from .header import Header
 from .help import HelpScreen
 from .left_panel import UprootTree
-from .plot import Plotext
+from .plot import Plotext, apply_selection
 from .tools import Info, Tools
 from .viewer import ViewWidget
 
@@ -108,14 +110,15 @@ class Browser(textual.app.App[None]):
         if isinstance(self.view_widget.item, Error):
             items = [self.view_widget.item]
         elif isinstance(self.view_widget.item, Plotext):
-            msg += (
-                f'\nitem = uproot_file["{self.view_widget.item.selection.lstrip("/")}"]'
-            )
-            if self.view_widget.item.expr:
-                msg += (
-                    f"\n# plotted histogram h sliced with: {self.view_widget.item.expr}"
-                )
-            items = [self.view_widget.item]
+            plotext = self.view_widget.item
+            msg += f'\nitem = uproot_file["{plotext.selection.lstrip("/")}"]'
+            *_, selected = apply_selection(plotext.upfile, plotext.selection.split(":"))
+            width = (plotext.size[0] - 5) * 4 if plotext.size else 100
+            with contextlib.suppress(RuntimeError):
+                msg += f"\n{uproot_browser.plot.dump(selected, width=width)}"
+                if plotext.expr:
+                    msg += f"\nh = {plotext.expr}"
+            items = [plotext]
 
         theme = "ansi_dark" if self.current_theme.dark else "ansi_light"
 

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -39,7 +39,7 @@ from .error import Error
 from .header import Header
 from .help import HelpScreen
 from .left_panel import UprootTree
-from .plot import Plotext, apply_selection, dump
+from .plot import Plotext, apply_selection, make_dump
 from .tools import Info, Tools
 from .viewer import ViewWidget
 
@@ -113,7 +113,7 @@ class Browser(textual.app.App[None]):
             *_, selected = apply_selection(plotext.upfile, plotext.selection.split(":"))
             size = plotext.size or ()
             with contextlib.suppress(RuntimeError):
-                msg += f"\n{dump(selected, *size, expr=plotext.expr)}"
+                msg += f"\n{make_dump(selected, *size, expr=plotext.expr)}"
             items = [plotext]
 
         theme = "ansi_dark" if self.current_theme.dark else "ansi_light"

--- a/src/uproot_browser/tui/plot.py
+++ b/src/uproot_browser/tui/plot.py
@@ -36,7 +36,7 @@ def make_plot(item: Any, theme: str, *size: int, expr: str) -> Any:
     return plt.build()
 
 
-def dump(item: Any, *size: int, expr: str = "") -> str:
+def make_dump(item: Any, *size: int, expr: str = "") -> str:
     """Standalone Python source rebuilding the plotted histogram as ``h``."""
     width = (size[0] - 5) * 4 if size else 100
     code = uproot_browser.plot.dump(item, width=width)

--- a/src/uproot_browser/tui/plot.py
+++ b/src/uproot_browser/tui/plot.py
@@ -36,6 +36,15 @@ def make_plot(item: Any, theme: str, *size: int, expr: str) -> Any:
     return plt.build()
 
 
+def dump(item: Any, *size: int, expr: str = "") -> str:
+    """Standalone Python source rebuilding the plotted histogram as ``h``."""
+    width = (size[0] - 5) * 4 if size else 100
+    code = uproot_browser.plot.dump(item, width=width)
+    if expr:
+        code += f"\nh = {expr}"
+    return code
+
+
 # wrapper for plotext into a textual widget
 @dataclasses.dataclass
 class Plotext:

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -8,7 +8,7 @@ import rich.console
 import uproot
 from skhep_testdata import data_path
 
-import uproot_browser.plot
+import uproot_browser.tui.plot
 from uproot_browser.tree import print_tree
 
 OUT1 = """\
@@ -140,9 +140,7 @@ def test_dump_is_runnable(selection: str, expr: str) -> None:
     uproot_file = uproot.open(data_path("uproot-Event.root"))
     item = uproot_file[selection]
 
-    code = uproot_browser.plot.dump(item, width=100)
-    if expr:
-        code += f"\nh = {expr}"
+    code = uproot_browser.tui.plot.dump(item, 105, 30, expr=expr)
 
     namespace: dict[str, object] = {"item": item}
     exec(code, namespace)

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -127,17 +127,18 @@ def test_tree_rntuple(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("selection", "expr"),
+    ("filename", "selection", "expr"),
     [
-        ("hstat", ""),
-        ("hstat", "h[50:]"),
-        ("T/event/fNtrack", ""),
-        ("T/event/fH", "h[::2j]"),
+        ("uproot-Event.root", "hstat", ""),
+        ("uproot-Event.root", "hstat", "h[50:]"),
+        ("uproot-Event.root", "T/event/fNtrack", ""),
+        ("uproot-Event.root", "T/event/fH", "h[::2j]"),
+        ("ntpl001_staff_rntuple_v1-0-0-0.root", "Staff/Age", "h[::2j]"),
     ],
 )
-def test_dump_is_runnable(selection: str, expr: str) -> None:
+def test_dump_is_runnable(filename: str, selection: str, expr: str) -> None:
     """The "Dump & Quit" source rebuilds the plotted histogram as ``h``."""
-    uproot_file = uproot.open(data_path("uproot-Event.root"))
+    uproot_file = uproot.open(data_path(filename))
     item = uproot_file[selection]
 
     code = uproot_browser.tui.plot.dump(item, 105, 30, expr=expr)

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import sys
 
 import hist
@@ -139,7 +140,11 @@ def test_tree_rntuple(capsys: pytest.CaptureFixture[str]) -> None:
 def test_dump_is_runnable(filename: str, selection: str, expr: str) -> None:
     """The "Dump & Quit" source rebuilds the plotted histogram as ``h``."""
     uproot_file = uproot.open(data_path(filename))
-    item = uproot_file[selection]
+    # Navigate key-by-key, like the tree browser does (RNTuple fields are not
+    # reachable via a recursive "a/b" lookup on the minimum uproot).
+    item = functools.reduce(
+        lambda obj, key: obj[key], selection.split("/"), uproot_file
+    )
 
     code = uproot_browser.tui.plot.dump(item, 105, 30, expr=expr)
 

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import sys
 
+import hist
 import pytest
 import rich.console
+import uproot
 from skhep_testdata import data_path
 
+import uproot_browser.plot
 from uproot_browser.tree import print_tree
 
 OUT1 = """\
@@ -121,3 +124,27 @@ def test_tree_rntuple(capsys: pytest.CaptureFixture[str]) -> None:
     out, err = capsys.readouterr()
     assert not err
     assert out == OUT2
+
+
+@pytest.mark.parametrize(
+    ("selection", "expr"),
+    [
+        ("hstat", ""),
+        ("hstat", "h[50:]"),
+        ("T/event/fNtrack", ""),
+        ("T/event/fH", "h[::2j]"),
+    ],
+)
+def test_dump_is_runnable(selection: str, expr: str) -> None:
+    """The "Dump & Quit" source rebuilds the plotted histogram as ``h``."""
+    uproot_file = uproot.open(data_path("uproot-Event.root"))
+    item = uproot_file[selection]
+
+    code = uproot_browser.plot.dump(item, width=100)
+    if expr:
+        code += f"\nh = {expr}"
+
+    namespace: dict[str, object] = {"item": item}
+    exec(code, namespace)
+
+    assert isinstance(namespace["h"], hist.Hist)

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -146,7 +146,7 @@ def test_dump_is_runnable(filename: str, selection: str, expr: str) -> None:
         lambda obj, key: obj[key], selection.split("/"), uproot_file
     )
 
-    code = uproot_browser.tui.plot.dump(item, 105, 30, expr=expr)
+    code = uproot_browser.tui.plot.make_dump(item, 105, 30, expr=expr)
 
     namespace: dict[str, object] = {"item": item}
     exec(code, namespace)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Followup to #235 (part of #233).

`d` (Dump & Quit) prints Python code to reproduce the current plot. #235 added the plot-input expression to that output, but only as a comment — so a sliced plot (e.g. `h[50:]`) still couldn't actually be reproduced by running the dump.

This emits **full runnable hist code** instead. A new `dump` `singledispatch` in `plot.py` (mirroring the existing `plot` dispatch table) generates standalone source that rebuilds the plotted histogram as `h`:

- **TH1** → `h = hist.Hist(item.to_hist())`
- **object branch** → `functools.reduce(operator.add, [x.to_hist() for x in arr])`
- **numeric branch** → the `awkward`/`numpy`/`hist.numpy.histogram` pipeline, with the live canvas `bins` baked in

The browser appends `h = <expr>` when an expression is present (it's `eval`'d against `h`, so this reproduces the slice exactly). Unplottable selections degrade gracefully to just the `item = ...` line.

Example dump for `hstat` with expression `h[50:]`:

```python
import uproot
uproot_file = uproot.open(".../uproot-Event.root")
item = uproot_file["hstat"]
import hist
h = hist.Hist(item.to_hist())
h = h[50:]
```

Adds a parametrized `test_dump_is_runnable` that `exec`s the generated source (histogram / numeric branch / object branch, with and without an expression) and asserts a `hist.Hist` results.