### PR TITLE
chore: ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,16 +87,10 @@ ipython_config.py
 #   intended to run in multiple environments; otherwise, check them in:
 # .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# uv
-#   This project does not pin dependencies, so the lock file is not tracked.
+# Lockfiles
+Pipfile.lock
 uv.lock
+*pylock*
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# uv
+#   This project does not pin dependencies, so the lock file is not tracked.
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This project doesn't track a lock file, so a locally generated `uv.lock` (created by `uv sync`) shows up in `git status` and is easy to commit by accident. Add it to `.gitignore`.