### PR TITLE
fix(tui): don't lazy-mount the Tools tab (Select mount race)

### DIFF
--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -77,7 +77,11 @@ class Browser(textual.app.App[None]):
                 with textual.widgets.TabPane("Tree"):
                     yield UprootTree(self.path, id="tree-view")
                 with textual.widgets.TabPane("Tools"):
-                    yield textual.lazy.Lazy(Tools())
+                    # Not lazy: lazy-mounting a Select races its internal mount
+                    # (SelectCurrent.update queries "#label" before that child is
+                    # mounted), which crashes on slow runners. Tools is cheap to
+                    # build anyway; only the Info tab is worth deferring.
+                    yield Tools()
                 with textual.widgets.TabPane("Info"):
                     yield textual.lazy.Lazy(Info())
             # main_panel

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -86,8 +86,8 @@ async def test_theme_select_tracks_theme() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
-        # Tools tab is lazy-loaded; activate it so the Select mounts and starts
-        # tracking the theme (Tools.on_mount sets up the watcher).
+        # Activate the Tools tab and wait for the Select to settle (Tools.on_mount
+        # sets up the watcher that keeps it in sync with the theme).
         pilot.app.query_one(
             "#left-view", textual.widgets.TabbedContent
         ).active = "tab-2"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The Windows CI flake in `test_theme_select_tracks_theme` (seen across #243/#245/#246) has a deeper root cause than the test-timing issues those PRs addressed: **Textual's `Select` crashes during its own mount** on slow runners.

Sequence:
1. `Select._on_mount` → `_init_selected_option()` sets the value
2. → `Select._watch_value` → `SelectCurrent.update()`
3. → `SelectCurrent.update` calls `self.query_one("#label", Static)`
4. but `#label` (from `SelectCurrent.compose`) **isn't mounted yet** → `NoMatches`

`Select._watch_value` guards `query_one(SelectCurrent)` with `try/except NoMatches`, but the inner `#label` lookup is unguarded. The Select then never receives a value (`Select.NULL`), which is exactly the `assert Select.NULL == 'textual-dark'` failure — and no amount of test-side `wait_until` can paper over a crash.

This started with #238, which wrapped the Tools tab in `textual.lazy.Lazy`; the deferred mount changes the ordering enough to trip the Textual bug on Windows.

## Fix

Mount the Tools tab eagerly; keep only the Info tab lazy. #238's lazy win was really about Info (it enumerates every installed distribution); Tools is just a `Select` + `Switch`, so deferring it buys little and exposes the Select-mount race.

## Notes

- Filing an upstream Textual issue for the unguarded `#label` query in `SelectCurrent.update` (separate from this PR).
- `prek -a` clean, full `tests/test_tui.py` passes.