### PR TITLE
feat(tui): fzf-style fuzzy finder to jump to branches (#192)

### DIFF
--- a/src/uproot_browser/tree.py
+++ b/src/uproot_browser/tree.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from rich.tree import Tree
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
 console = Console()
 
@@ -100,6 +100,12 @@ class UprootEntry:
             UprootEntry(f"{self.path}/{key}", self.item[key])
             for key in sorted(get_children(self.item))
         ]
+
+    def walk(self) -> Iterator[UprootEntry]:
+        """Yield every descendant entry depth-first (not including self)."""
+        for child in self.children:
+            yield child
+            yield from child.walk()
 
 
 def make_tree(node: UprootEntry, *, tree: Tree | None = None) -> Tree:

--- a/src/uproot_browser/tui/README.md
+++ b/src/uproot_browser/tui/README.md
@@ -9,6 +9,11 @@ something to plot. Press `spacebar` to open/close a directory or tree. You can
 also use the VIM keys: `j` to move down, `k` to move up, `l` to open a folder,
 and `h` to close a folder.
 
+Press `/` to open a fuzzy finder: start typing a branch or field name and the
+list narrows as you type (`fzf`-style). Use the arrow keys to pick a match and
+press `enter` to jump to it in the tree (plotting it if it's plottable), or
+`esc` to cancel.
+
 You can also open the command palette with `ctrl-p`, which gives you some
 options like changing the theme, writing out an SVG, or quitting the program.
 

--- a/src/uproot_browser/tui/browser.css
+++ b/src/uproot_browser/tui/browser.css
@@ -100,6 +100,22 @@ HelpScreen {
     align: center middle;
 }
 
+JumpScreen {
+    align: center middle;
+}
+
+#jump-dialog {
+    width: 60%;
+    height: 60%;
+    padding: 0 1;
+    border: thick $background 80%;
+    background: $surface;
+}
+
+#jump-results {
+    height: 1fr;
+}
+
 .dialog {
     padding: 0 1;
     width: 80%;

--- a/src/uproot_browser/tui/browser.py
+++ b/src/uproot_browser/tui/browser.py
@@ -38,6 +38,7 @@ with contextlib.suppress(AttributeError):
 from .error import Error
 from .header import Header
 from .help import HelpScreen
+from .jump import JumpScreen
 from .left_panel import UprootTree
 from .plot import Plotext, apply_selection, make_dump
 from .tools import Info, Tools
@@ -53,6 +54,7 @@ class Browser(textual.app.App[None]):
     CSS_PATH = "browser.css"
     BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
         textual.binding.Binding("b", "toggle_files", "Navbar"),
+        textual.binding.Binding("/", "jump", "Jump"),
         textual.binding.Binding("q", "quit", "Quit"),
         textual.binding.Binding("d", "quit_with_dump", "Dump & Quit"),
         textual.binding.Binding("f1", "help", "Help"),
@@ -74,7 +76,7 @@ class Browser(textual.app.App[None]):
         with textual.containers.Container():
             # left_panel
             with textual.widgets.TabbedContent(id="left-view"):
-                with textual.widgets.TabPane("Tree"):
+                with textual.widgets.TabPane("Tree", id="tree-tab"):
                     yield UprootTree(self.path, id="tree-view")
                 with textual.widgets.TabPane("Tools"):
                     # Not lazy: lazy-mounting a Select races its internal mount
@@ -98,6 +100,17 @@ class Browser(textual.app.App[None]):
 
     def action_help(self) -> None:
         self.push_screen(HelpScreen())
+
+    def action_jump(self) -> None:
+        """Open the fuzzy finder to jump to a branch/field."""
+        tree = self.query_one("#tree-view", UprootTree)
+        self.push_screen(JumpScreen(tree.all_entries()), self._on_jumped)
+
+    def _on_jumped(self, path: str | None) -> None:
+        if path is None:
+            return
+        self.query_one("#left-view", textual.widgets.TabbedContent).active = "tree-tab"
+        self.query_one("#tree-view", UprootTree).select_path(path)
 
     def action_toggle_files(self) -> None:
         """Called in response to key binding."""

--- a/src/uproot_browser/tui/jump.py
+++ b/src/uproot_browser/tui/jump.py
@@ -38,9 +38,7 @@ class JumpScreen(textual.screen.ModalScreen[str | None]):
 
     def compose(self) -> textual.app.ComposeResult:
         with textual.containers.Container(id="jump-dialog"):
-            yield textual.widgets.Input(
-                placeholder="Jump to branch…", id="jump-input"
-            )
+            yield textual.widgets.Input(placeholder="Jump to branch…", id="jump-input")
             yield textual.widgets.OptionList(id="jump-results")
 
     def on_mount(self) -> None:

--- a/src/uproot_browser/tui/jump.py
+++ b/src/uproot_browser/tui/jump.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import ClassVar
+
+import rich.text
+import textual.app
+import textual.binding
+import textual.containers
+import textual.fuzzy
+import textual.screen
+import textual.widgets
+from textual.widgets.option_list import Option
+
+
+@dataclasses.dataclass
+class Candidate:
+    """A jump target: a node's full path plus how to display it."""
+
+    path: str
+    name: str  # final path segment, what the fuzzy query matches against
+    icon: str
+    is_dir: bool
+
+
+class JumpScreen(textual.screen.ModalScreen[str | None]):
+    """fzf-style finder: fuzzy-match a node's name, return its path."""
+
+    BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
+        textual.binding.Binding("down", "cursor_down", "Down", show=False),
+        textual.binding.Binding("up", "cursor_up", "Up", show=False),
+        textual.binding.Binding("escape", "cancel", "Cancel", show=False),
+    ]
+
+    def __init__(self, candidates: list[Candidate]) -> None:
+        self.candidates = candidates
+        super().__init__()
+
+    def compose(self) -> textual.app.ComposeResult:
+        with textual.containers.Container(id="jump-dialog"):
+            yield textual.widgets.Input(
+                placeholder="Jump to branch…", id="jump-input"
+            )
+            yield textual.widgets.OptionList(id="jump-results")
+
+    def on_mount(self) -> None:
+        self._populate("")
+        self.query_one("#jump-input", textual.widgets.Input).focus()
+
+    def _populate(self, query: str) -> None:
+        results = self.query_one("#jump-results", textual.widgets.OptionList)
+        results.clear_options()
+
+        if query:
+            matcher = textual.fuzzy.Matcher(query)
+            scored = [(matcher.match(c.name), c) for c in self.candidates]
+            candidates = [
+                c
+                for _, c in sorted(
+                    ((s, c) for s, c in scored if s > 0),
+                    key=lambda sc: sc[0],
+                    reverse=True,
+                )
+            ]
+        else:
+            candidates = self.candidates
+
+        results.add_options([Option(self._label(c), id=c.path) for c in candidates])
+        if candidates:
+            results.highlighted = 0
+
+    @staticmethod
+    def _label(candidate: Candidate) -> rich.text.Text:
+        display = candidate.path.lstrip("/")
+        prefix = display[: len(display) - len(candidate.name)]
+        text = rich.text.Text(candidate.icon)
+        text.append(prefix, style="dim")
+        text.append(candidate.name, style="bold")
+        return text
+
+    def on_input_changed(self, event: textual.widgets.Input.Changed) -> None:
+        self._populate(event.value)
+
+    def on_input_submitted(self) -> None:
+        results = self.query_one("#jump-results", textual.widgets.OptionList)
+        if results.highlighted is None:
+            return
+        option = results.get_option_at_index(results.highlighted)
+        self.dismiss(option.id)
+
+    def on_option_list_option_selected(
+        self, event: textual.widgets.OptionList.OptionSelected
+    ) -> None:
+        self.dismiss(event.option.id)
+
+    def action_cursor_down(self) -> None:
+        self.query_one("#jump-results", textual.widgets.OptionList).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#jump-results", textual.widgets.OptionList).action_cursor_up()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/uproot_browser/tui/left_panel.py
+++ b/src/uproot_browser/tui/left_panel.py
@@ -12,6 +12,7 @@ import textual.widgets.tree
 import uproot
 
 from ..tree import UprootEntry
+from .jump import Candidate
 from .messages import UprootSelected
 
 if TYPE_CHECKING:
@@ -32,7 +33,58 @@ class UprootTree(textual.widgets.Tree[UprootEntry]):
         self.upfile = uproot.open(path)
         file_path = Path(self.upfile.file_path)
         data = UprootEntry("/", self.upfile)
+        self._candidates: list[Candidate] | None = None
         super().__init__(name=str(file_path), data=data, label=file_path.stem, **args)
+
+    def all_entries(self) -> list[Candidate]:
+        """All jump targets in the file, built once and cached."""
+        if self._candidates is None:
+            root = UprootEntry("/", self.upfile)
+            self._candidates = [
+                Candidate(
+                    path=entry.path,
+                    name=entry.path.rstrip("/").rsplit("/", 1)[-1],
+                    icon=entry.meta()["label_icon"],
+                    is_dir=entry.is_dir,
+                )
+                for entry in root.walk()
+            ]
+        return self._candidates
+
+    def select_path(self, target: str) -> None:
+        """Navigate to (and reveal) the node at ``target``, plotting leaves."""
+        node = self.root
+        self.load_directory(node)
+        while node.data is not None and node.data.path != target:
+            child = next(
+                (
+                    c
+                    for c in node.children
+                    if c.data is not None
+                    and (c.data.path == target or target.startswith(c.data.path + "/"))
+                ),
+                None,
+            )
+            if child is None:
+                return
+            self.load_directory(child)
+            if child.data is not None and child.data.path != target:
+                child.expand()
+            node = child
+
+        target_node = node
+
+        def reveal() -> None:
+            self.move_cursor(target_node)
+            self.scroll_to_node(target_node)
+
+        self.call_after_refresh(reveal)
+
+        if target_node.data is not None:
+            if target_node.data.is_dir:
+                target_node.expand()
+            else:
+                self.post_message(UprootSelected(self.upfile, target_node.data.path))
 
     def render_label(
         self,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -115,13 +115,16 @@ async def test_jump_opens_and_lists_all() -> None:
     async with Browser(
         skhep_testdata.data_path("uproot-Event.root")
     ).run_test() as pilot:
+        # Grab the tree before opening the modal: older Textual scopes
+        # app.query_one to the active screen, so #tree-view is unreachable
+        # once the JumpScreen is on top.
+        expected = len(pilot.app.query_one("#tree-view", UprootTree).all_entries())
         await pilot.press("/")
         assert isinstance(pilot.app.screen, JumpScreen)
         results = pilot.app.screen.query_one(
             "#jump-results", textual.widgets.OptionList
         )
-        tree = pilot.app.query_one("#tree-view", UprootTree)
-        assert results.option_count == len(tree.all_entries())
+        assert results.option_count == expected
 
 
 async def test_jump_filters_and_plots() -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,7 +5,11 @@ import textual.pilot
 import textual.widgets
 
 from uproot_browser.tui.browser import Browser
+from uproot_browser.tui.jump import JumpScreen
+from uproot_browser.tui.left_panel import UprootTree
 from uproot_browser.tui.plot import Plotext
+
+LEAF_PATH = "//T/event/fFlag"
 
 
 async def wait_until(
@@ -105,6 +109,71 @@ async def test_theme_select_tracks_theme() -> None:
         pilot.app.theme = "nord"
         await wait_until(pilot, lambda: select.value == "nord")
         assert select.value == "nord"
+
+
+async def test_jump_opens_and_lists_all() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        await pilot.press("/")
+        assert isinstance(pilot.app.screen, JumpScreen)
+        results = pilot.app.screen.query_one(
+            "#jump-results", textual.widgets.OptionList
+        )
+        tree = pilot.app.query_one("#tree-view", UprootTree)
+        assert results.option_count == len(tree.all_entries())
+
+
+async def test_jump_filters_and_plots() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        await pilot.press("/")
+        await pilot.press(*"fflag")  # fuzzy-matches only fFlag
+        await pilot.pause()
+        results = pilot.app.screen.query_one(
+            "#jump-results", textual.widgets.OptionList
+        )
+        assert results.get_option_at_index(0).id == LEAF_PATH
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, JumpScreen)
+        item = pilot.app.view_widget.item
+        assert isinstance(item, Plotext)
+        assert item.selection == LEAF_PATH
+
+
+async def test_jump_expands_ancestors() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        tree = pilot.app.query_one("#tree-view", UprootTree)
+        tree.select_path(LEAF_PATH)
+        await wait_until(
+            pilot,
+            lambda: (
+                tree.cursor_node is not None
+                and tree.cursor_node.data is not None
+                and tree.cursor_node.data.path == LEAF_PATH
+            ),
+        )
+        node = tree.cursor_node
+        assert node is not None
+        assert node.data is not None
+        assert node.data.path == LEAF_PATH
+
+
+async def test_jump_cancel() -> None:
+    async with Browser(
+        skhep_testdata.data_path("uproot-Event.root")
+    ).run_test() as pilot:
+        await pilot.press("/")
+        assert isinstance(pilot.app.screen, JumpScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, JumpScreen)
+        assert pilot.app.view_widget.item is None
 
 
 async def test_help_focus() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #192.

Adds an fzf-style fuzzy finder for quickly jumping to a branch/field instead of scrolling the tree by hand — the common workflow when inspecting TTree/RNTuple contents, especially in large files.

## How it works
- Press **`/`** to open a modal finder (`JumpScreen`).
- Type to fuzzy-match nodes by their **leaf name** (final path segment); the full path is shown so you can tell same-named branches apart.
- **All** nodes are jump targets: `Enter` on a leaf navigates + plots it; `Enter` on a directory/tree navigates + expands it. `Esc` cancels. Arrow keys move through results.

## Implementation
- `tree.py` — `UprootEntry.walk()` generator enumerating all descendants (reuses existing `is_dir`/`children`).
- `tui/jump.py` (new) — `JumpScreen(ModalScreen[str | None])`: `Input` + `OptionList`, ranked with `textual.fuzzy.Matcher`.
- `tui/left_panel.py` — `all_entries()` (candidate list, built once and cached) and `select_path()` (descends by full-path prefix — avoiding the root `//` quirk — expanding ancestors, then reveals via `move_cursor`/`scroll_to_node`, posting the existing `UprootSelected` for leaves).
- `tui/browser.py` — `/` binding, `action_jump`, and a callback that switches to the Tree tab and navigates.
- `browser.css` / `tui/README.md` — modal styling and help text.

Stays within the Textual API available at the pinned floor (`>=0.86.0`), verified against the `minimums` venv. Per-character match highlighting was intentionally dropped because `Matcher.highlight`'s return type changed (`rich.Text` → `Content`) between 0.86 and current; the matched leaf is styled bold instead.

## Tests
Four new pilot tests in `tests/test_tui.py`: finder opens and lists all entries, query filters and the selected leaf plots, jumping expands collapsed ancestors, and `Esc` cancels. Full suite (18) passes; `prek -a` clean (ruff ALL + mypy strict).

> Note: `nox -s minimums` currently fails at collection on Python 3.14 due to an old `pytest-asyncio` pin (`asyncio.iscoroutinefunction` deprecation-as-error) — pre-existing and unrelated to this change.