### PR TITLE
chore: secure CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,38 +7,44 @@ on:
       - published
 
 concurrency:
-  group: ${ github.workflow }-${ github.ref }
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: hynek/build-and-inspect-python-package@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
 
   publish:
     name: Publish
     environment: pypi
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write  # for PyPI trusted publishing and attestations
+      attestations: write  # to store the build provenance attestation
     needs: [dist]
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: dist
         name: Packages
 
     - name: Generate artifact attestation for sdist and wheel
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-path: "dist/uproot_browser-*"
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,30 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   pre-commit:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.x"
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
     - name: PyLint
       run: pipx run nox -s pylint
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read  # to check out the repository
     strategy:
       fail-fast: false
       matrix:
@@ -34,14 +42,16 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - uses: astral-sh/setup-uv@v8.0.0
+    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
     - name: Install nox
       run: uv tool install nox
@@ -54,11 +64,13 @@ jobs:
       run: nox -s minimums
 
   pass:
+    name: Pass
     if: always()
     needs: [pre-commit, checks]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
     - rich>=12
     - click
     - hist
-    - numpy
+    # 2.4+ stubs need python_version 3.12+, but we target 3.10
+    - numpy<2.4
     - textual>=0.86
 
 - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -19,14 +19,15 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.15.15"
+  # Held at v0.15.15; v0.16 adds new rules that current sources fail.
+  rev: "0671d8ab202c4ac093b78433ae5baf74f3fc7246"  # frozen: v0.15.15
   hooks:
     - id: ruff-check
       args: ["--fix", "--show-fixes"]
     - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.1.0
+  rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
   hooks:
   - id: mypy
     files: src
@@ -38,10 +39,17 @@ repos:
     - textual>=0.86
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.2
+  rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
   hooks:
   - id: codespell
     args: [-L, "hist,iterm"]
+
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+  hooks:
+  - id: zizmor
+    files: "^\\.github"
+    args: [--persona=pedantic]
 
 - repo: local
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ dev = [
   {include-group = "test"},
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/uproot_browser/_version.py"


### PR DESCRIPTION
Prompted by https://github.com/pypa/hatch/issues/2292.

:robot: _AI text below_ :robot:

- Pin every GitHub Action to a full commit SHA with a version comment.
- Add `permissions: {}` at workflow level and give each job only the permissions it needs, with a comment for each one.
- Add `persist-credentials: false` to all checkout steps.
- Correct the broken concurrency expression in `cd.yml` (`${ ... }` -> `${{ ... }}`).
- Give the `pass` job a name.
- Add a 7-day cooldown to Dependabot and rename the group to `github-actions`.
- Add the zizmor pre-commit hook and update the other hooks, frozen to SHAs.
- Add `exclude-newer = "7 days"` to `[tool.uv]`.

Ruff stays at v0.15.15. Version 0.16 adds `CPY001` to the stable rules, which the sources fail. That update needs its own change set.